### PR TITLE
Add .Net 4.6 target

### DIFF
--- a/IdParser/IdParser.csproj
+++ b/IdParser/IdParser.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45;net46</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>4.0.1.1-asteres</Version>
+    <Version>4.0.1</Version>
     <Authors>Connor O'Shea</Authors>
     <Company />
     <Product>ID Parser</Product>
@@ -13,8 +13,8 @@
     <PackageProjectUrl>https://github.com/c0shea/IdParser</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/c0shea/IdParser/master/NuGet%20Package%20Icon.png</PackageIconUrl>
     <PackageTags>Drivers License Identification Card Parser PDF417 AAMVA Standard</PackageTags>
-    <AssemblyVersion>4.0.1.1</AssemblyVersion>
-    <FileVersion>4.0.1.1</FileVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <FileVersion>4.0.1.0</FileVersion>
     <PackageReleaseNotes></PackageReleaseNotes>
     <SignAssembly>False</SignAssembly>
     <RootNamespace>IdParser</RootNamespace>

--- a/IdParser/IdParser.csproj
+++ b/IdParser/IdParser.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net45;net46</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>4.0.1</Version>
+    <Version>4.0.1.1-asteres</Version>
     <Authors>Connor O'Shea</Authors>
     <Company />
     <Product>ID Parser</Product>
@@ -13,8 +13,8 @@
     <PackageProjectUrl>https://github.com/c0shea/IdParser</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/c0shea/IdParser/master/NuGet%20Package%20Icon.png</PackageIconUrl>
     <PackageTags>Drivers License Identification Card Parser PDF417 AAMVA Standard</PackageTags>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <FileVersion>4.0.1.0</FileVersion>
+    <AssemblyVersion>4.0.1.1</AssemblyVersion>
+    <FileVersion>4.0.1.1</FileVersion>
     <PackageReleaseNotes></PackageReleaseNotes>
     <SignAssembly>False</SignAssembly>
     <RootNamespace>IdParser</RootNamespace>


### PR DESCRIPTION
I have some legacy code on .Net 4.6 that could benefit from the recent updates to IdParser error handling. And it would be nice to continue using an "official" package rather than a custom build.
