### PR TITLE
Fixed lb to kg / kg to lb conversion error.

### DIFF
--- a/IdParser.Test/WeightTests.cs
+++ b/IdParser.Test/WeightTests.cs
@@ -62,5 +62,35 @@ namespace IdParser.Test
 
             Assert.AreEqual("33 kg", actual);
         }
+
+        [TestMethod]
+        public void PoundsToKilogramsTest()
+        {
+            var weight = Weight.FromImperial(175);
+            var expectedKg = 79.4;
+
+            Assert.IsTrue(weight.Kilograms.Value.Equals1DigitPrecision(expectedKg));
+        }
+
+        [TestMethod]
+        public void PoundsTest()
+        {
+            // This is internally converted to kg. Ensure it is round-tripped back to the expected value.
+            var weight = Weight.FromImperial(175);
+            var expected = "175 lbs";
+
+            Assert.AreEqual(expected, weight.ToString()); ;
+        }
+    }
+
+    internal static class DoubleExtensions
+    {
+        private const double _1Digit = 0.1;
+
+        internal static bool Equals1DigitPrecision(this double value, double comparison)
+        {
+            var difference = Math.Abs(value - comparison);
+            return difference < _1Digit;
+        }
     }
 }

--- a/IdParser/Weight.cs
+++ b/IdParser/Weight.cs
@@ -11,6 +11,17 @@ namespace IdParser
     {
         private const double PoundsPerKilogram = 2.20462262;
 
+        private static double PoundsToKilograms(int pounds)
+        {
+            return pounds / PoundsPerKilogram;
+        }
+
+        private static int KilogramsToPounds(double kilograms)
+        {
+            return (int)Math.Round(kilograms * PoundsPerKilogram, 0);
+        }
+
+
         // In order for JSON serialization and deserialization to work in both Json.NET
         // and ServiceStack.Text, an immutable type has to:
         // - Be a class and not a struct (immutable structs do not deserialize in ServiceStack)
@@ -34,7 +45,7 @@ namespace IdParser
 
         public static Weight FromImperial(int pounds)
         {
-            return new Weight(null, pounds * PoundsPerKilogram, false);
+            return new Weight(null, PoundsToKilograms(pounds), false);
         }
 
         public static Weight FromRange(WeightRange weightRange)
@@ -44,7 +55,7 @@ namespace IdParser
 
         internal void SetImperial(int pounds)
         {
-            Kilograms = pounds * PoundsPerKilogram;
+            Kilograms = PoundsToKilograms(pounds);
             IsMetric = false;
         }
 
@@ -71,7 +82,7 @@ namespace IdParser
                 return $"{Kilograms} kg";
             }
 
-            return $"{(int)(Kilograms.Value / PoundsPerKilogram)} lbs";
+            return $"{KilogramsToPounds(Kilograms.Value)} lbs";
         }
 
         #region IComparable


### PR DESCRIPTION
For a weight of 175 lbs, I was expecting to see about 79.4 kg, but it was displaying 385.8.

Looking at the `Weight` class, it appears the conversions were backward:

```
kg = pounds * PoundsPerKilogram
lb = kilograms / PoundsPerKilogram
```

I believe it should be the other way around, so I swapped them:

```
kg = pounds / PoundsPerKilogram
lb = kilograms * PoundsPerKilogram
```

I also added a couple of unit tests to check the conversion.

Thank you,

Jon