### PR TITLE
Fixed one of the branches in HairColorParser setting EyeColor instead of HairColor

### DIFF
--- a/IdParser/Parsers/Id/HairColorParser.cs
+++ b/IdParser/Parsers/Id/HairColorParser.cs
@@ -45,7 +45,7 @@ namespace IdParser.Parsers.Id
             // West Virginia doesn't follow the abbreviation scheme for brown
             else if (input.EqualsIgnoreCase("BN"))
             {
-                IdCard.EyeColor = EyeColor.Brown;
+                IdCard.HairColor = HairColor.Brown;
             }
             else if (input.EqualsIgnoreCase(HairColor.Gray.GetAbbreviation()))
             {


### PR DESCRIPTION
One of the `if` statements in `HairColorParser` was setting the `EyeColor` property instead of `HairColor`. This pull request fixes that.